### PR TITLE
Implement Invasion

### DIFF
--- a/boards.py
+++ b/boards.py
@@ -1,8 +1,12 @@
-from typing import TYPE_CHECKING
+import logging
 
+from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from generators import T_GENERATOR
     from goals import T_GOAL
+    
+_log = logging.getLogger("byngosink")
+_log.propagate = False
 
 class Board():
     """Basic unbiased board"""
@@ -10,6 +14,7 @@ class Board():
     def __init__(self, w, h, generator: "T_GENERATOR", seed: str) -> None:
         self.width = w
         self.height = h
+        self.generator = generator
         self.game = generator.game
         self.generatorName = generator.name
         self.languages = generator.languages
@@ -19,7 +24,10 @@ class Board():
     
     def __min_view(self):
         return {"type": self.name, "width": self.width, "height": self.height,
-                "game": self.game, "generatorName": self.generatorName}
+                "maxMarksPerSquare": self.max_marks_per_square(), "game": self.game, "generatorName": self.generatorName}
+    
+    def max_marks_per_square(self):
+        return 0  # Infinity
     
     def get_minimum_view(self) -> dict:
         """Provides a minimum amount of data on the board for display (used for unteamed users)"""
@@ -38,34 +46,37 @@ class Board():
         return self.__min_view() | {"goals": {i:g.get_repr() for i, g in enumerate(self.goals)},
                                           "marks": {t:list(g) for t, g in self.marks.items()}}
     
-    def can_mark(self, index, teamid):
+    def can_mark(self, index, teamid) -> bool:
         """Checked on mark and occasionally as extra board view detail (eg invasion, roguelike)"""
-        return True
+        return teamid is not None and index not in self.marks.get(teamid, {})
     
     def mark(self, index: int, teamid: str) -> bool:
         if not self.can_mark(index, teamid): return False
 
         if teamid not in self.marks: 
             self.marks[teamid] = {index}
-        elif index in self.marks[teamid]: 
-            return False
         else: 
             self.marks[teamid].add(index)
         return True
+
+    def can_unmark(self, index, teamid) -> bool:
+        """Checked on unmark to maintain board invariants."""
+        return teamid in self.marks and index in self.marks[teamid]
     
     def unmark(self, index, teamid) -> bool:
-        if teamid not in self.marks: 
-            return False
-        elif index not in self.marks[teamid]: 
-            return False
-        else: 
-            self.marks[teamid].remove(index)
-        return False
+        if not self.can_unmark(index, teamid): return False
+
+        marks = self.marks[teamid]
+        marks.remove(index)
+        if not marks:
+            self.marks.remove(teamid)
+        return True
 
     def get_dict(self) -> dict:
         return {"type": str(type(self)),
                 "width": self.width,
                 "height": self.height,
+                "maxMarksPerSquare": self.max_marks_per_square(),
                 "goals": self.goals,
                 "marks": self.marks}
 
@@ -82,12 +93,151 @@ class Bingo(Board):
 class Lockout(Bingo):
     """Basic lockout bingo board"""
     name = "Lockout"
+
+    # TODO: Chaos lockout
+    def max_marks_per_square(self):
+        return 1
+
     def can_mark(self, index, teamid):
-        allmarked = set().union(*self.marks.values())
-        if index in allmarked:
-            return False
+        marked = set([v for marks in self.marks.values() for v in marks])
+        return index not in marked
+
+INVASION_TOP = 1
+INVASION_LEFT = 2
+INVASION_RIGHT = 3
+INVASION_BOTTOM = 4
+INVASION_ALL = frozenset([1, 2, 3, 4])
+
+class Invasion(Lockout):
+    """Basic invasion bingo board"""
+    name = "Invasion"
+    def __init__(self, generator: "T_GENERATOR", seed) -> None:
+        super().__init__(generator, seed)
+        self.start_constraints = dict()  # teamId -> invasionStart
+
+        self.ranks = dict()  # constraint -> list[set(index)]
+        self.ranks[INVASION_TOP] = [frozenset([self.index(x, y) for x in range(self.width)]) for y in range(self.height)]
+        self.ranks[INVASION_LEFT] = [frozenset([self.index(x, y) for y in range(self.height)]) for x in range(self.width)]
+        self.ranks[INVASION_RIGHT] = list(reversed(self.ranks[INVASION_LEFT]))
+        self.ranks[INVASION_BOTTOM] = list(reversed(self.ranks[INVASION_TOP]))
+
+    def other_team(self, teamid):
+        for t in self.start_constraints:
+            if t != teamid: return t
+
+    def index(self, x, y):
+        return x + y * self.width
+
+    def inv_marks(self):
+        d = dict()
+        for teamid, marks in self.marks.items():
+            for index in marks:
+                d[index] = teamid
+        return d
+    
+    def valid_progression(self, teamid, constraint):  # set(index)
+        inv = self.inv_marks()
+
+        filled = []
+        available = []
+        for r, rank in enumerate(self.ranks[constraint]):
+            f = 0
+            a = []
+            for i in rank:
+                t = inv.get(i, None)
+                if t == teamid:
+                    f += 1
+                elif t is None:
+                    a.append(i)
+            filled.append(f)
+            available.append(a)
+
+        # Each rank is only available if the fill count is less than the previous rank.
+        l = []
+        for r in range(len(filled)):
+            if r == 0 or filled[r - 1] > filled[r]:
+                l.extend(available[r])
+        return frozenset(l)
+
+    def valid_moves(self, teamid):  # dict[index: set(constraint)]
+        constraints = INVASION_ALL
+        if teamid not in self.start_constraints:
+            if len(self.start_constraints) == 2:
+                # Only two teams can play invasion.
+                constraints = [] 
+            elif len(self.start_constraints) == 1:
+                # Can only start on the opposite constraints.
+                constraints = [5 - c for c in self.start_constraints[self.other_team(teamid)]]
         else:
+            constraints = self.start_constraints[teamid]
+        
+        d = dict()
+        for c in constraints:
+            for i in self.valid_progression(teamid, c):
+                d[i] = d.get(i, frozenset()).union(frozenset([c]))
+        return d
+    
+    def update_constraints(self, teamid, constraints):
+        self.start_constraints[teamid] = constraints
+
+        oid = self.other_team(teamid)
+        if oid is not None:
+            # Constrain the opposing team if they started in a corner.
+            self.start_constraints[oid] = frozenset([5 - c for c in constraints]).intersection(self.start_constraints[oid])
+
+    def mark(self, index, teamid) -> bool:
+        moves = self.valid_moves(teamid)
+        c = moves.get(index, None)
+        if c is not None:
+            super().mark(index, teamid)
+
+            # Update constraints
+            self.update_constraints(teamid, c)
             return True
+        else:
+            return False
+    
+    def replay(self, teamid, indexes, constraints) -> bool:
+        tomove = set(indexes)
+        while tomove:
+            moves = self.valid_moves(teamid)
+            found = False
+            for i in tomove:
+                c = moves.get(i, None)
+                if c is not None and c.issuperset(constraints):
+                    tomove.remove(i)
+                    super().mark(i, teamid)
+                    self.update_constraints(teamid, c)
+                    found = True
+                    break
+            
+            if not found: return False
+        return True
+
+    def unmark(self, index, teamid) -> bool:
+        if not self.can_unmark(index, teamid): return False
+
+        # Unmark is only allowed if the resulting board state is valid.
+        # Attempt to regenerate it, and if successful, use the regen.
+        b = Invasion(self.generator, self.seed)
+
+        toplay = set(self.marks[teamid])
+        toplay.remove(index)
+        if not b.replay(teamid, toplay, self.start_constraints.get(teamid, INVASION_ALL)):
+            return False
+
+        oid = self.other_team(teamid)
+        if oid is not None:
+            if not b.replay(oid, self.marks.get(oid, []), self.start_constraints.get(oid, INVASION_ALL)):
+                return False
+
+        self.marks = b.marks
+        self.start_constraints = b.start_constraints
+        return True
+
+    def get_team_view(self, teamId) -> dict: 
+        """`extras`: valid next moves"""
+        return super().get_team_view(teamId) | {"extras": {"invasionMoves": list(self.valid_moves(teamId).keys())}}
 
 class Exploration(Board):
     """13x13 board with marks hidden between teams and only adjacent goals displayed. 
@@ -123,7 +273,6 @@ class Exploration(Board):
                                           "marks": {t:list(g) for t, g in self.marks.items()}}
 
     def can_mark(self, index: int, teamid: str) -> bool:
-        if teamid is None: return False
         seen = self._get_seen(teamid)
         if index not in seen: return False
         else: return True
@@ -191,6 +340,7 @@ class GTTOS13(GTTOS):
 ALIASES = {
     "Non-Lockout": Bingo,
     "Lockout": Lockout,
+    "Invasion": Invasion,
     "Exploration": Exploration13,
     "GTTOS": GTTOS13
 }

--- a/rooms.py
+++ b/rooms.py
@@ -6,10 +6,11 @@ import logging
 from boards import create_board
 from generators import get_generator
 
-from typing import TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from socket_handler import DecoratedWebsocket
+    T_WEBSOCKET = Union[DecoratedWebsocket, None]
 
 _log = logging.getLogger("byngosink")
 
@@ -28,7 +29,7 @@ COLOURS = {
 
 class Room():
     class User():
-        def __init__(self, name: str, room, websocket: "DecoratedWebsocket" | None = None) -> None:
+        def __init__(self, name: str, room, websocket: "T_WEBSOCKET" = None) -> None:
             self.id = str(uuid4())
             self.name = name
             self.socket = websocket

--- a/socket_handler.py
+++ b/socket_handler.py
@@ -221,9 +221,12 @@ async def UNMARK(websocket: DecoratedWebsocket, data):
     if params is None: return
     user, room, goal_id = params
 
-    room.board.unmark(int(goal_id), user.teamId)
-    await websocket.send_json({"verb": "UNMARKED", "goalId": goal_id})
-    await room.alert_board_changes()
+    # TODO: Communicate failure in e.g. invasion, lockout, etc.
+    if room.board.unmark(int(goal_id), user.teamId):
+        await websocket.send_json({"verb": "UNMARKED", "goalId": goal_id})
+        await room.alert_board_changes()
+    else:
+        await websocket.send_json({"verb": "NOUNMARK", "goalId": goal_id})
 
 async def SPECTATE(websocket: DecoratedWebsocket, data):
     room_id = data.get("roomId", None)


### PR DESCRIPTION
Makes server side changes to support invasion, including 'valid move' metadata sent to the client.

I tried to reproduce the stated rules as faithfully as possible but please double-check.  I used a narrowing constraint system so that starting at a corner goal doesn't "commit" you to either side until you choose a goal that does, or your opponents choose a side.  This means you can stay uncommitted by marking goals along the diagonal, which may or may not be an intentional side effect.  I also waffled a fair bit on how to define undo.  For simplicity, I made it so that you can only undo a move if the new state is also a valid Invasion board state that can be reproduced from the existing goals (e.g., if you chain goals in columns 1-4, then try to undo a goal in column 3, it won't let you because that would make the goal in column 4 invalid and we'd rather not have to handle that state).

The implementation is as compact and clean as I could think of but it still has some funky corner cases.  For instance, there is 'hidden' state in the form of "where did team A/B start" which affects legal moves, but cannot be inferred from the current board state alone.  If a team marks goals in columns 1-5 using a left->right strategy before the opposing team marks any goals, it can be ambiguous from the final state whether they started on the left or right (or even top/bottom if going diagonally).  This would allow them to then mark a second goal on the right if the server allowed the ambiguity, which is nonsense, so the server doesn't allow this by remembering the starting side.  However, this means that if you start with a corner goal, then mark a goal next to it, you are still ambiguous (did you mark 2 goals on your starting line, or 1 on start and 1 on next?) and since this state is load-bearing, you cannot undo the corner goal first since that would make the starting side unambiguous.  These edge cases are mostly academic and I think unlikely to matter in any competitive races, but regardless worth noting.  (Honestly if your opponents get across the board before you've marked any goals maybe that should be a Skunk-type victory.)